### PR TITLE
Div. Verbesserungen und fixes im Template

### DIFF
--- a/guides/Hinweise-zum-IG-Template/Übersicht/Offene-Punkte/erledigt/FQL-on-Depencencies-don-t-work.page.md
+++ b/guides/Hinweise-zum-IG-Template/Übersicht/Offene-Punkte/erledigt/FQL-on-Depencencies-don-t-work.page.md
@@ -1,0 +1,31 @@
+## {{page-title}}
+
+### Redering Profiles from Dependencies work:
+
+{ {render:https://gematik.de/fhir/isik/v3/Dokumentenaustausch/StructureDefinition/ISiKDokumentenSuchergebnisse}}
+{{render:https://gematik.de/fhir/isik/v3/Dokumentenaustausch/StructureDefinition/ISiKDokumentenSuchergebnisse}}
+
+### FQLs from Dependencies don't work
+Udate: fixed in Version 2024.5.3!! 
+
+"using closure" in FQL hinzufügen
+
+```
+using closure
+from
+	StructureDefinition
+where
+	url = 'https://gematik.de/fhir/isik/v3/Dokumentenaustausch/StructureDefinition/ISiKDokumentenSuchergebnisse'
+select
+	Canonical: url, Status: status, Version: version, Basis: baseDefinition
+```
+    
+<fql output="transpose">
+using closure
+from
+	StructureDefinition
+where
+	url = 'https://gematik.de/fhir/isik/v3/Dokumentenaustausch/StructureDefinition/ISiKDokumentenSuchergebnisse'
+select
+	Canonical: url, Status: status, Version: version, Basis: baseDefinition
+</fql>

--- a/guides/Hinweise-zum-IG-Template/Übersicht/Offene-Punkte/erledigt/toc.yaml
+++ b/guides/Hinweise-zum-IG-Template/Übersicht/Offene-Punkte/erledigt/toc.yaml
@@ -1,3 +1,5 @@
+- name: FQL on Depencencies don't work
+  filename: FQL-on-Depencencies-don-t-work.page.md
 - name: Index
   filename: Index.page.md
 - name: subject Variable in FQL

--- a/guides/Hinweise-zum-IG-Template/Übersicht/Offene-Punkte/toc.yaml
+++ b/guides/Hinweise-zum-IG-Template/Übersicht/Offene-Punkte/toc.yaml
@@ -16,5 +16,3 @@
   filename: Feature-Requests
 - name: erledigt
   filename: erledigt
-- name: FQL on Depencencies don't work
-  filename: FQL-on-Depencencies-don-t-work.page.md

--- a/guides/Hinweise-zum-IG-Template/Übersicht/ReleaseNotes.page.md
+++ b/guides/Hinweise-zum-IG-Template/Übersicht/ReleaseNotes.page.md
@@ -1,5 +1,13 @@
 ## {{page-title}}
 
+### 13.9.2024
+* `fixed` FQL Queries auf CapabilityStatement funktionieren nun auch bei multiplen Ressourcentypen
+
+### 19.8.2024
+* `fixed` statische URL in FQL-Statement von ValueSet und CodeSystem auf Canonical-Variable korrigiert
+* `fixed` defekter PageLink im Template für CodeSystem korrigiert
+* `changed` neues Simplifier-Feature (ab Version 2024.5.2) output=transpose für Metadata-Tabellen verwendet.
+
 ### Version 0.0.4
 * `added` Template für (SDC-)Questionnaires hinzugefügt
 * `changed` [HDB-210](https://hl7germany.atlassian.net/issues/HDB-210) Startseite umbenannt in "Übersicht"

--- a/guides/IG-Template/Übersicht/Artefakte/Extensions/Template.page.md
+++ b/guides/IG-Template/Übersicht/Artefakte/Extensions/Template.page.md
@@ -11,7 +11,7 @@ expand: 2
 
 ### Metadaten
 
-<fql>
+<fql output="transpose" headers="true">
 from
 	StructureDefinition
 where

--- a/guides/IG-Template/Übersicht/Artefakte/Operations/Template.page.md
+++ b/guides/IG-Template/Übersicht/Artefakte/Operations/Template.page.md
@@ -12,14 +12,14 @@ expand: 2
 
 ### Metadaten
 
-@```
+<fql output="transpose" headers="true">
 from
 	OperationDefinition
 where
-	url = 'http://hl7.org/fhir/OperationDefinition/Resource-meta-add'
+	url = %canoncial
 select
 	Canonical: url, Status: status, Version: version
-```
+</fql>
 
 
 

--- a/guides/IG-Template/Übersicht/Artefakte/Questionnaires/Template.page.md
+++ b/guides/IG-Template/Übersicht/Artefakte/Questionnaires/Template.page.md
@@ -11,7 +11,7 @@ expand: 2
 
 ### Metadaten
 
-<fql>
+<fql output="transpose" headers="true">
 from
 	Questionnaire
 where

--- a/guides/IG-Template/Übersicht/Artefakte/Ressourcen-Profile/FQL-Capability-Operations.page.md
+++ b/guides/IG-Template/Übersicht/Artefakte/Ressourcen-Profile/FQL-Capability-Operations.page.md
@@ -1,9 +1,13 @@
 <fql>
 from
-	CapabilityStatement
+    CapabilityStatement
 where
-	url = %capability
-	where rest.resource.type = %resType 
-		for rest.resource.operation  
-			select Name: name, Spezifikation: definition, Verbindlichkeit: extension('http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation').value
+    url = %capability
+for rest.resource.where(type = %resType).operation
+select
+{
+     Name: name,
+     Spezifikation: definition,
+     Verbindlichkeit: extension('http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation').value
+}
 </fql> 

--- a/guides/IG-Template/Übersicht/Artefakte/Ressourcen-Profile/FQL-Capability-REST.page.md
+++ b/guides/IG-Template/Übersicht/Artefakte/Ressourcen-Profile/FQL-Capability-REST.page.md
@@ -1,9 +1,13 @@
 <fql>
 from
-	CapabilityStatement
+    CapabilityStatement
 where
-	url = %capability
-	where rest.resource.type = %resType 
-	for  rest.resource.interaction
- 		select Interaktion: code, Verbindlichkeit: extension		('http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation').value
+    url = %capability
+for rest.resource.where(type = %resType).interaction
+select
+{
+     Interaktion: code,
+     Typ: type,
+     Verbindlichkeit: extension('http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation').value
+}
 </fql>

--- a/guides/IG-Template/Übersicht/Artefakte/Ressourcen-Profile/FQL-Capability-Search.page.md
+++ b/guides/IG-Template/Übersicht/Artefakte/Ressourcen-Profile/FQL-Capability-Search.page.md
@@ -1,9 +1,13 @@
 <fql>
 from
-	CapabilityStatement
+    CapabilityStatement
 where
-	url = %capability
-	where rest.resource.type = %resType
-		for rest.resource.searchParam  
-			select Parameter: name, Typ: type, Verbindlichkeit: extension('http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation').value
+    url = %capability
+for rest.resource.where(type = %resType).searchParam
+select
+{
+     Parameter: name,
+     Typ: type,
+     Verbindlichkeit: extension('http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation').value
+}
 </fql>

--- a/guides/IG-Template/Übersicht/Artefakte/Ressourcen-Profile/Template.page.md
+++ b/guides/IG-Template/Übersicht/Artefakte/Ressourcen-Profile/Template.page.md
@@ -15,7 +15,7 @@ expand: 1
 
 ### Metadaten
 
-<fql output="table" headers="true">
+<fql output="transpose" headers="true">
 from
 	StructureDefinition
 where

--- a/guides/IG-Template/Übersicht/Artefakte/Terminologien/CodeSystems/FQL-Beschreibung.page.md
+++ b/guides/IG-Template/Übersicht/Artefakte/Terminologien/CodeSystems/FQL-Beschreibung.page.md
@@ -2,7 +2,7 @@
 from
 	CodeSystem
 where
-	url = 'http://example.org/CodeSystem/MeinCodeSystem'
+	url = %canonical
 select
 	Beschreibung: description
 </fql>

--- a/guides/IG-Template/Übersicht/Artefakte/Terminologien/CodeSystems/Template.page.md
+++ b/guides/IG-Template/Übersicht/Artefakte/Terminologien/CodeSystems/Template.page.md
@@ -9,7 +9,7 @@ canonical: http://example.org/CodeSystem/MeinCodeSystem
 
 ### Metadaten
 
-<fql output="table">
+<fql output="transpose" headers="true">
 from
 	CodeSystem
 where
@@ -36,7 +36,7 @@ select
 ```
     </tab>
     <tab title="Beschreibung">
-    {{page:Startseite/Artefakte/Terminologien/CodeSystems/FQL-Beschreibung.page.md}}
+    {{page:Übersicht/Artefakte/Terminologien/CodeSystems/FQL-Beschreibung.page.md}}
     </tab>
     <tab title="XML">      
         {{xml}}

--- a/guides/IG-Template/Übersicht/Artefakte/Terminologien/ValueSets/FQL-Beschreibung.page.md
+++ b/guides/IG-Template/Übersicht/Artefakte/Terminologien/ValueSets/FQL-Beschreibung.page.md
@@ -2,7 +2,7 @@
 from
 	ValueSet
 where
-	url = 'http://example.org/ValueSet/MeinValueSet'
+	url = %canonical
 select
 	Beschreibung: description
 </fql>

--- a/guides/IG-Template/Übersicht/Artefakte/Terminologien/ValueSets/Template.page.md
+++ b/guides/IG-Template/Übersicht/Artefakte/Terminologien/ValueSets/Template.page.md
@@ -10,7 +10,7 @@ canonical: http://example.org/ValueSet/MeinValueSet
 
 ### Metadaten
 
-<fql output="table">
+<fql output="transpose" headers="true">
 from
 	ValueSet
 where


### PR DESCRIPTION
…bei multiplen Ressourcentypen

* `fixed` statische URL in FQL-Statement von ValueSet und CodeSystem auf Canonical-Variable korrigiert
* `fixed` defekter PageLink im Template für CodeSystem korrigiert
* `changed` neues Simplifier-Feature (ab Version 2024.5.2) output=transpose für Metadata-Tabellen verwendet.